### PR TITLE
Bug Fix:  don't rely on case comparisons

### DIFF
--- a/cloudbackup/client/auth.py
+++ b/cloudbackup/client/auth.py
@@ -445,7 +445,7 @@ class Authentication(Command):
             for service in self.auth_data['access']['serviceCatalog']:
                 if service['name'] == 'cloudBackup':
                     for endpoint in service['endpoints']:
-                        if endpoint['region'] == dc:
+                        if endpoint['region'].lower() == dc.lower():
                             if useServiceNet:
                                 dcuri = endpoint['internalURL']
                             else:


### PR DESCRIPTION
- Finding the Cloud Backup API URL in the service catalog was doing a bad comparison on the end-point regions since it didn't force the two to the same case for the comparison