### PR TITLE
Enhancement run manual backup

### DIFF
--- a/cloudbackup/client/agents.py
+++ b/cloudbackup/client/agents.py
@@ -259,6 +259,7 @@ class AgentLogLevel(Command):
             l.append(o)
             self.body = json.dumps(l)
             res = requests.patch(self.Uri, headers=self.Headers, data=self.Body)
+
         if res.status_code == 204:
             return True
         else:
@@ -1217,44 +1218,6 @@ class Agents(Command):
         else:
             self.log.error('Unable to retrieve agent configuration for agent id ' + str(machine_agent_id) + '. Server returned ' + str(res.status_code) + ': ' + res.text + ' Reason: ' + res.reason)
             return False
-
-    def RemoveAgentConfiguration(self, machine_agent_id, backup_id):
-        if self.api_version == 1:
-            self.ReInit(self.sslenabled,
-                        '/v1.0/{0}/backup-configuration/{1}'.format(
-                            self.authenticator.AuthTenantId,
-                            backup_id
-                        )
-            )
-            self.headers['X-Auth-Token'] = self.authenticator.AuthToken
-            self.headers['Content-Type'] = 'application/json; charset=utf-8'
-            res = requests.delete(self.Uri, headers=self.Headers)
-            if res.status_code in (200, 204):
-                return True
-            else:
-                self.log.error('Unable to delete backup configuration {0} for agent {1}'
-                               .format(backup_id, machine_agent_id))
-                return False
-
-        else:
-            self.ReInit(self.sslenabled,
-                        '/v{0}/{1}/configurations/{2}'.format(
-                            self.api_version,
-                            self.project_id,
-                            backup_id
-                        )
-            )
-            self.headers['X-Auth-Token'] = self.authenticator.AuthToken
-            self.headers['Content-Type'] = 'application/json; charset=utf-8'
-            self.headers['X-Project-Id'] = self.project_id
-            res = requests.delete(self.Uri, headers=self.Headers)
-            if res.status_code == 204:
-                return True
-            else:
-                self.log.error('Unable to delete backup configuration {0} for agent {1}'
-                               .format(backup_id, machine_agent_id))
-                return False
-
 
     @property
     def AgentConfigurationIds(self):

--- a/cloudbackup/cmd/shell.py
+++ b/cloudbackup/cmd/shell.py
@@ -919,6 +919,24 @@ class CloudBackupApiShell(object):
 
         return info
 
+    def doPrintLatestAgentActivity(self, active_agent_id):
+        activities = self.agents.GetAgentLatestActivity(active_agent_id)
+        print('Agent ID: {0}'.format(active_agent_id))
+        if len(activities):
+            for activity in activities:
+                print('\t{0} - {1}'.format(
+                          activity['id'],
+                          activity['name']
+                      )
+                )
+                print('\t\tType: {0}'.format(activity['type']))
+                print('\t\tState: {0}'.format(activity['state']))
+                print('\t\tTime: {0}'.format(activity['time']))
+
+        else:
+            print('\tNo Activity to report')
+
+        print('\n')
 
     def WorkOnSpecificAgentConfiguration(self, active_agent_id, config_id, config_name):
         specific_config_menu = [
@@ -1131,7 +1149,8 @@ class CloudBackupApiShell(object):
                 agent_detail_menu = [
                     { 'index': 1, 'text': 'Show Details', 'type': 'details' },
                     { 'index': 2, 'text': 'Access Configuration', 'type': 'configuration' },
-                    { 'index': 3, 'text': 'Return to previous menu', 'type': 'returnToPrevious' }
+                    { 'index': 3, 'text': 'Check agent activity', 'type': 'actionCheckActivity' },
+                    { 'index': 4, 'text': 'Return to previous menu', 'type': 'returnToPrevious' }
                 ]
 
                 selection = cloudbackup.utils.menus.promptSelection(
@@ -1161,6 +1180,9 @@ class CloudBackupApiShell(object):
 
                 elif selection['type'] == 'configuration':
                     self.WorkOnAgentConfiguration(active_agent_id)
+
+                elif selection['type'] == 'actionCheckActivity':
+                    self.doPrintLatestAgentActivity(active_agent_id)
 
             # stop our thread that is keeping the agent alive
             print('Allowing the agent to throttle down...')


### PR DESCRIPTION
- Bug Fix: There was already functionality in cloudbackup.clients.backups for removing backup configurations, use that instead of adding more code to cloudbackup.client.agents
- Enhancement: Added RSE functionality to wake the agent when we start working on a specific agent
- Enhancement: Add functionality to start a backup manually
- Enhancement: Add functionality to check on the status of a backup configuration
- Access the latest stream of activity messages for a given agent through the API and display them in a semi-meanful manner for the user
- Condenses down the activity message instead of displaying it all, tried to keep information that was the same between both versions of API since there is such a disparity in the format for the two
- Added lookup of the configuration names to try to give the user a sensible activity message
- Tested against V2 API; unable to find an agent against V1 API to test with, all came back reportin no activity for the sample I did (IAD and ORD DCs)