### PR TITLE
Bug Fix: Default version and projectid value

### DIFF
--- a/cloudbackup/client/agents.py
+++ b/cloudbackup/client/agents.py
@@ -139,7 +139,7 @@ class AgentLogLevel(Command):
     """
     Object controlling the log levels for agents
     """
-    def __init__(self, sslenabled, authenticator, apihost, api_version, project_id):
+    def __init__(self, sslenabled, authenticator, apihost, api_version=1, project_id=None):
         super(self.__class__, self).__init__(sslenabled, apihost, '/')
         self.log = logging.getLogger(__name__)
 
@@ -320,7 +320,7 @@ class AgentDetails(object):
     Object describing a given Agent instance described by the Agent Details API Endpoint
     """
 
-    def __init__(self, details, version):
+    def __init__(self, details, version=1):
 
         # TODO: Replace this verification and use JSON Schema
         self.version = version
@@ -537,7 +537,7 @@ class AgentConfiguration(object):
     Object describing the various Agent configurations
     """
 
-    def __init__(self, configuration, version):
+    def __init__(self, configuration, version=1):
 
         # TODO: Replace this verification and use JSON Schema
         self.version = version
@@ -910,7 +910,7 @@ class Agents(Command):
     Presently supports the RAX v1.0 API
     """
 
-    def __init__(self, sslenabled, authenticator, apihost, api_version, project_id):
+    def __init__(self, sslenabled, authenticator, apihost, api_version=1, project_id=None):
         """
         Initialize the Agent access
           sslenabled - True if using HTTPS; otherwise False

--- a/cloudbackup/client/backup.py
+++ b/cloudbackup/client/backup.py
@@ -1053,8 +1053,8 @@ class Backups(Command):
     Object to manage backup operations
     """
 
-    def __init__(self, sslenabled, authenticator, apihost, api_version,
-                 project_id):
+    def __init__(self, sslenabled, authenticator, apihost, api_version=1,
+                 project_id=None):
         """
         Initialize the backups
           sslenabled - True if using HTTPS; otherwise False
@@ -1886,8 +1886,8 @@ class Restores(Command):
     '''
     Object to manage restore operations
     '''
-    def __init__(self, sslenabled, authenticator, apihost, api_version,
-                 project_id):
+    def __init__(self, sslenabled, authenticator, apihost, api_version=1,
+                 project_id=None):
         super(self.__class__, self).__init__(sslenabled, apihost, '/')
         self.log = logging.getLogger(__name__)
         # save the ssl status for the various reinits done for each API call supported


### PR DESCRIPTION
- When introducing the v2 API we also started requiring the API version as a parameter to certain classes as well as the projectid (required by v2 API and later). This broke existing scripts that did not set these. Adding defaults for v1 API so it should work.