### PR TITLE
Enhancement: Shell can access v1 Backup Reports

### DIFF
--- a/cloudbackup/cmd/shell/interface.py
+++ b/cloudbackup/cmd/shell/interface.py
@@ -77,10 +77,12 @@ class CloudBackupApiShell(object):
             self.datacenter,
             self.use_servicenet
         )
+        self.log.debug('Cloud Backup API URI: {0}'.format(self.api['uri']))
         self.api['version'] = self.auth_engine.GetCloudBackupApiVersion(
             self.datacenter,
             self.use_servicenet
         )
+        self.log.debug('Cloud Backup API Version: {0}'.format(self.api['version']))
         # TODO: Add support for Test/Pre-Prod API
 
         self.agents = cloudbackup.client.agents.Agents(
@@ -687,6 +689,7 @@ class CloudBackupApiShell(object):
                 while True:
                     # Get the latest set of backups so the menu is always up-to-date
                     all_backups = self.backup_engine.GetAllBackupsForConfiguration(
+                        active_agent_id,
                         config_id
                     )
 
@@ -729,6 +732,7 @@ class CloudBackupApiShell(object):
                             indent=4
                         )
                         print(report_data)
+                        cloudbackup.utils.menus.promptUserAnyKey()
 
             elif selection['type'] == 'actionDelete':
                 verify_delete = cloudbackup.utils.menus.promptYesNoCancel(

--- a/cloudbackup/utils/menus.py
+++ b/cloudbackup/utils/menus.py
@@ -219,3 +219,12 @@ def promptUserInputNumber(prompt, prefix='', min_value=0, max_value=99999, show_
         return None
     else:
         return int(user_result)
+
+
+def promptUserAnyKey(prompt='Press any key to continue'):
+    """Prompt user to press any key as a delay or paging method"
+    """
+    if six.PY2:
+        raw_input(prompt)
+    else:
+        input(prompt)


### PR DESCRIPTION
- Bug Fix: Correct how we set the hard-coded v2 API URL since customers only in LON may have only 1 single end-point in their service-catalog as well
- Enhancement: Added support for retrieving a list of all the agent backup activities for v1 API
- Enhancement: Added menu for the backup reports to the shell
- Enhancement: Added support to select a backup report, print it, and wait for the user before continuing in case of really long list of backup reports
- Enhancement: Added "press any key" wait-prompt